### PR TITLE
[FEATURE] Allow more flexible naming of target locations

### DIFF
--- a/src/Resolving/PartialNamingHelper.php
+++ b/src/Resolving/PartialNamingHelper.php
@@ -22,11 +22,6 @@ class PartialNamingHelper
         $parts = array_map('ucfirst', explode('-', $patternName));
         $type = array_shift($parts);
         switch ($type) {
-            case 'Atoms':
-            case 'Molecules':
-            case 'Organisms':
-                return $directory . DIRECTORY_SEPARATOR . 'Resources/Private/Partials/' . $this->determinePatternSubPath($patternName) . '.html';
-                break;
             case 'Templates':
                 return $directory . DIRECTORY_SEPARATOR . 'Resources/Private/Templates/Default/' . implode('/', $parts) . '.html';
                 break;
@@ -34,13 +29,7 @@ class PartialNamingHelper
                 return $directory . DIRECTORY_SEPARATOR . 'Resources/Private/Templates/Page/' . implode('/', $parts) . '.html';
                 break;
             default:
-                throw new \RuntimeException(
-                    sprintf(
-                        'The pattern type "%s" (implied from "%s") is unknown.',
-                        $type,
-                        $originalPatternName
-                    )
-                );
+                return $directory . DIRECTORY_SEPARATOR . 'Resources/Private/Partials/' . $this->determinePatternSubPath($patternName) . '.html';
                 break;
         }
     }


### PR DESCRIPTION
Pattern Lab does not require the Atoms, Molecules, Organisms naming from Atomic Design and even within Atomic Design there is room to create naming that is friendly for your team and/or client.  This means we shouldn't force the default naming when we export.

This pull requests simply keeps the default naming and handling for Templates and Pages and treats *everything* else as a directory inside partials.  I could also see merit to an alternate approach that lets you define your allowed types or extracts them from the file structure.  