### PR TITLE
[BUGFIX] Emulate view helper not called

### DIFF
--- a/src/Emulation/PatternLabViewHelperInvoker.php
+++ b/src/Emulation/PatternLabViewHelperInvoker.php
@@ -54,9 +54,7 @@ class PatternLabViewHelperInvoker extends ViewHelperInvoker
                 }
                 return $tagBuilder->render();
             }
-            if ($outputsTagContent) {
-                return $renderChildrenClosure();
-            }
+            return $content;
         }
     }
 }


### PR DESCRIPTION
When a non-tag emulate view helper is used, no content is returned. This is due to the fact the closure to render the children is null.

This patch fixes this by returning the content which is calculated before instead of calling the renderChildrenClosure, which is null.